### PR TITLE
Add Riddler as a collector

### DIFF
--- a/lib/aquatone/collectors/riddler.rb
+++ b/lib/aquatone/collectors/riddler.rb
@@ -5,17 +5,15 @@ module Aquatone
         :name         => "Riddler",
         :author       => "Joel (@jolle)",
         :description  => "Uses Riddler by F-Secure to find hostnames",
-        :require_keys => ["riddler"]
+        :require_keys => ["riddler_username", "riddler_password"]
       }
 
       API_BASE_URI = "https://riddler.io"
 
       def run
-        credentials = get_key("riddler").split(":", 2)
-
         auth_response = post_request("#{API_BASE_URI}/auth/login", {
-          :email    => credentials[0].strip,
-          :password => credentials[1].strip
+          :email    => get_key("riddler_username"),
+          :password => get_key("riddler_password")
         }.to_json, {
           :headers  => { "Content-Type" => "application/json" }
         })

--- a/lib/aquatone/collectors/riddler.rb
+++ b/lib/aquatone/collectors/riddler.rb
@@ -1,0 +1,45 @@
+module Aquatone
+  module Collectors
+    class Riddler < Aquatone::Collector
+      self.meta = {
+        :name         => "Riddler",
+        :author       => "Joel (@jolle)",
+        :description  => "Uses Riddler by F-Secure to find hostnames",
+        :require_keys => ["riddler"]
+      }
+
+      API_BASE_URI = "https://riddler.io"
+
+      def run
+        credentials = get_key("riddler").split(":", 2)
+
+        auth_response = post_request("#{API_BASE_URI}/auth/login", {
+          :email    => credentials[0].strip,
+          :password => credentials[1].strip
+        }.to_json, {
+          :headers  => { "Content-Type" => "application/json" }
+        })
+
+        if auth_response.code == 400 or auth_response.parsed_response["meta"]["code"] == 400
+          failure("Invalid credentials to Riddler.io")
+        elsif auth_response.code != 200 or auth_response.parsed_response["meta"]["code"] != 200
+          failure("Riddler.io auth API returned unexpected response code: #{response.code}")
+        end
+        
+        token = auth_response.parsed_response["response"]["user"]["authentication_token"]
+
+        response = post_request("#{API_BASE_URI}/api/search", {
+          :query  => "pld:#{url_escape(domain.name)}",
+          :output => "host",
+          :limit  => 500
+        }.to_json, {
+          :headers  => { "Content-Type" => "application/json", "Authentication-Token" => token }
+        })
+
+        response.parsed_response.each do |record|
+          add_host(record["host"]) unless record["host"].empty?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Riddler (https://riddler.io, by F-Secure) is a service that provides information about hosts similarly to what Shodan does. This pull request adds Riddler's API as a collector and thus allows getting hosts from Riddler.

Riddler's API does not use keys like Shodan and VirusTotal, rather username and password combinations. These combinations are added just like keys, but a colon (`:`) separates the username and password. If there is a better way to do this, please let me know.

The API requires an authentication token that is retrieved with the previously mentioned username and password with an auth login request. After the token has been retrieved, calling the search API will result in a list of information that has been requested, in this case: hosts. The query used, `pld:[domain]`, searches for all hosts that have the given domain ("pay level domain", https://riddler.io/help/search).