### PR TITLE
Change default aquatone assessment directory to a dot folder.

### DIFF
--- a/lib/aquatone.rb
+++ b/lib/aquatone.rb
@@ -25,7 +25,7 @@ require "aquatone/collector"
 
 module Aquatone
   AQUATONE_ROOT         = File.expand_path(File.join(File.dirname(__FILE__), "..")).freeze
-  DEFAULT_AQUATONE_PATH = File.join(Dir.home, "aquatone").freeze
+  DEFAULT_AQUATONE_PATH = File.join(Dir.home, ".aquatone").freeze
 
   def self.aquatone_path
     ENV['AQUATONEPATH'] || DEFAULT_AQUATONE_PATH


### PR DESCRIPTION
Hi Michael,

Great tools there! Can i suggest that the default assessment directory be a dot folder (like msf, cme, sqlmap, etc.)?

Thanks,