### PR TITLE
Remove fastly takeover false positive

### DIFF
--- a/lib/aquatone/detectors/fastly.rb
+++ b/lib/aquatone/detectors/fastly.rb
@@ -9,12 +9,15 @@ module Aquatone
       }
 
       CNAME_VALUE          = ".fastly.net".freeze
+      CNAME_FALSE_POSITIVE = ".map.fastly.net".freeze
       RESPONSE_FINGERPRINT = "Fastly error: unknown domain".freeze
 
       def run
         return false unless cname_resource?
         if resource_value.end_with?(CNAME_VALUE)
-          return get_request("http://#{host}/").body.include?(RESPONSE_FINGERPRINT)
+          unless resource_value.end_with?(CNAME_FALSE_POSITIVE)
+            return get_request("http://#{host}/").body.include?(RESPONSE_FINGERPRINT)
+          end
         end
         false
       end


### PR DESCRIPTION
When the CNAME leads to *.map.fastly.com the CNAME is not vulnerable to takeover as it is customer-specific.

see: https://docs.fastly.com/guides/basic-setup/adding-cname-records#customer-specific-hostnames