### PR TITLE
Add Cert Spotter collector

### DIFF
--- a/lib/aquatone/collectors/certspotter.rb
+++ b/lib/aquatone/collectors/certspotter.rb
@@ -1,0 +1,27 @@
+module Aquatone
+  module Collectors
+    class CertSpotter < Aquatone::Collector
+      self.meta = {
+        :name         => "Cert Spotter",
+        :author       => "Joel (@jolle)",
+        :description  => "Uses Cert Spotter by SSLMate to find hostnames"
+      }
+
+      def run
+        response = get_request("https://certspotter.com/api/v0/certs?domain=#{url_escape(domain.name)}")
+
+        if response.code != 200
+          failure("Cert Spotter API returned an unexpected response code: #{response.code}")
+        end
+
+        response.parsed_response.each do |cert|
+          cert['dns_names'].each do |name|
+            if /\.#{Regexp.escape(domain.name)}$/.match?(name) or name == domain.name
+              add_host(name)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cert Spotter (https://sslmate.com/certspotter/) is a service by SSLMate that provides an API to search SSL certificates. Even though Aquatone has crt.sh already, I thought this could still (in some cases) provide results. Also, Cert Spotter was [requested on Twitter](https://twitter.com/Th3G3nt3lman/status/914086191321956353).