### PR TITLE
Add ThreatMiner collector

### DIFF
--- a/lib/aquatone/collectors/threatminer.rb
+++ b/lib/aquatone/collectors/threatminer.rb
@@ -1,0 +1,24 @@
+# https://www.threatminer.org/getData.php?e=subdomains_container&q=hs.fi&t=0&rt=10&p=1
+module Aquatone
+  module Collectors
+    class ThreatMiner < Aquatone::Collector
+      self.meta = {
+        :name         => "ThreatMiner",
+        :author       => "Joel (@jolle)",
+        :description  => "Uses ThreatMiner to find hostnames"
+      }
+
+      def run
+        response = get_request("https://www.threatminer.org/getData.php?e=subdomains_container&q=#{url_escape(domain.name)}&t=0&rt=10&p=1")
+
+        if response.code != 200
+          failure("ThreatMiner returned an unexpected response code: #{response.code}")
+        end
+
+        response.body.to_enum(:scan, /"domain\.php\?q=([a-zA-Z0-9\*_.-]+\.#{Regexp.escape(domain.name)})"/).map do |link|
+          add_host(link[0])
+        end
+      end
+    end
+  end
+end

--- a/lib/aquatone/collectors/threatminer.rb
+++ b/lib/aquatone/collectors/threatminer.rb
@@ -1,4 +1,3 @@
-# https://www.threatminer.org/getData.php?e=subdomains_container&q=hs.fi&t=0&rt=10&p=1
 module Aquatone
   module Collectors
     class ThreatMiner < Aquatone::Collector


### PR DESCRIPTION
While investigating another potential collector, Robtex, I stumbled upon ThreatMiner (https://www.threatminer.org/about.php), a website that collects information about threats, etc. and offers a subdomain list when a domain is supplied. By using the same XHR request the site makes (and using regex to parse some HTML), it is quite easy to scrape the subdomains.