### PR TITLE
Adding a --keep-unresolved option

### DIFF
--- a/exe/aquatone-discover
+++ b/exe/aquatone-discover
@@ -11,6 +11,10 @@ options = {
 OptionParser.new do |opts|
   opts.banner = "Usage: aquatone-discover OPTIONS"
 
+  opts.on("--keep-unresolved", "Keep domains regardless of resovability") do |v|
+    options[:keep_unresolved] = v
+  end
+
   opts.on("-d", "--domain DOMAIN", "Domain name to assess") do |v|
     if !Aquatone::Validation.valid_domain_name?(v)
       puts "#{v} doesn't look like a valid domain name."

--- a/lib/aquatone/commands/discover.rb
+++ b/lib/aquatone/commands/discover.rb
@@ -11,6 +11,7 @@ module Aquatone
         @assessment      = Aquatone::Assessment.new(options[:domain])
         @hosts           = [options[:domain]]
         @host_dictionary = {}
+        @keep_unresolved = options[:keep_unresolved]
 
         banner("Discover")
         setup_resolver
@@ -108,6 +109,9 @@ module Aquatone
             next if exclude_ip?(ip)
             @host_dictionary[host] = ip
             output("#{ip.ljust(15)} #{bold(host)}\n")
+          elsif @keep_unresolved
+            @host_dictionary[host] = ""
+            output("#{''.ljust(15)} #{bold(host)}\n")
           end
           jitter_sleep
           task_count += 1


### PR DESCRIPTION
Hello,

Aquatone is a fantastic tool which I've been using for several months. One requirement that I have though is to keep all hosts regardless of their resolvability status in DNS. 

To accommodate this feature, I've added an option "--keep-unresolved" which will simply keep and print all hosts if passed. 

I'm hoping you'll be okay with adding this small addition to the mainline release as keeping support with any new changes would be desirable rather than having to maintain a separate fork.

Thanks in advance and let me know if anything should be modified or if you'd prefer not to have this feature. 