### PR TITLE
Fix Nightmare node command execution

### DIFF
--- a/lib/aquatone/browser/drivers/nightmare.rb
+++ b/lib/aquatone/browser/drivers/nightmare.rb
@@ -17,14 +17,7 @@ module Aquatone
         end
 
         def visit
-          rout, wout = IO.pipe
-          process           = ChildProcess.build(*construct_command)
-          process.cwd       = Aquatone::AQUATONE_ROOT
-          process.io.stdout = wout
-          process.start
-          process.poll_for_exit(options[:timeout])
-          wout.close
-          command_output = rout.readlines.join("\n").strip
+          command_output = `#{construct_command.join(' ')}`
           JSON.parse(command_output)
         rescue JSON::ParserError
           fail IncompatabilityError, "Nightmarejs must be run on a system with a graphical desktop session (X11)"


### PR DESCRIPTION
Fixes #63 by using `Open3` to execute the node command instead of `ChildProcess`. Output of the test environment used in #63:

```
➜  aquatone git:(nightmare-fix) aquatone-gather --domain localhost.dev
                           __
  ____ _____ ___  ______ _/ /_____  ____  ___
 / __ `/ __ `/ / / / __ `/ __/ __ \/ __ \/ _ \
/ /_/ / /_/ / /_/ / /_/ / /_/ /_/ / / / /  __/
\__,_/\__, /\__,_/\__,_/\__/\____/_/ /_/\___/
        /_/  gather v0.5.0 - by @michenriksen

Installing Nightmare.js package, please wait... Done

Processing 1 pages...
Processed: http://127.0.0.1:8989/ (localhost) - 200 OK

Finished processing pages:

 - Successful : 1
 - Failed     : 0

Generating report...done
```