### PR TITLE
Fixed: Support string response headers

### DIFF
--- a/aquatone.js
+++ b/aquatone.js
@@ -120,9 +120,13 @@ nightmare
     visit.code   = result.code;
     visit.status = result.code + " " + (HTTP_RESPONSES[visit.code] || "(unknown)")
     var headers  = {};
-    for (var k in result.headers) {
-      headers[prettyHeader(k)] = result.headers[k].join(" ");
-    }
+	for (var k in result.headers) {
+		if(typeof result.headers[k] === "array") {
+			headers[prettyHeader(k)] = result.headers[k].join(" ");
+		} else {
+			headers[prettyHeader(k)] = result.headers[k];
+		}
+	}
     visit.headers = headers;
     return nightmare
       .wait(1000)

--- a/lib/aquatone/report.rb
+++ b/lib/aquatone/report.rb
@@ -67,7 +67,12 @@ module Aquatone
       when 'x-permitted-cross-domain-policies'
         :success if value.downcase == 'master-only'
       when 'x-content-type-options'
-        :success if value.downcase == 'nosniff'
+        value = value.join(",")
+        if value.downcase == 'nosniff'
+          :success
+        else
+          :danger
+        end
       when 'strict-transport-security'
         :success
       when 'x-frame-options'
@@ -75,6 +80,7 @@ module Aquatone
       when 'public-key-pins'
         :success
       when 'x-xss-protection'
+        value = value.join(",")
         if value.start_with?('1')
           :success
         else


### PR DESCRIPTION
I had errors while running Aquatone against Netflix:

> Failed: http://<censored>/ (<censored>.netflix.com) - result.headers[k].join is not a function

So I fixed that result.headers can be strings (instead of arrays).