### PR TITLE
Fixing PTRArchive (with updated URL)

### DIFF
--- a/lib/aquatone/collectors/ptrarchive.rb
+++ b/lib/aquatone/collectors/ptrarchive.rb
@@ -8,7 +8,11 @@ module Aquatone
       }
 
       def run
-        response = get_request("http://ptrarchive.com/tools/search.htm?label=#{url_escape(domain.name)}&date=ALL")
+        response = get_request("http://ptrarchive.com/tools/search3.htm?label=#{url_escape(domain.name)}&date=ALL",
+         :headers => {
+           "User-Agent" => "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100402 Prism/1.0b4"
+         }
+        )
         if response.code != 200
           failure("PTRArchive returned unexpected response code: #{response.code}")
         end


### PR DESCRIPTION
Note: This commit resolves an issue with the PTRArchive collector.
There is another pull request that exists for this issue, but I believe
it’s hitting a URL that’s since been changed.

However, the owner of PTRArchive seems to not be a huge fan of tools querying the data, and seems to be indiscriminately labeling all applications (even those with legitimate utility for penetration testers) 'black hat tools'. In the case of a similar project, Sublist3r, they removed PTRArchive completely after discovering actual tampering of the returned data and wholesale blocking of their requests. This might also explain why the URL has shifted between my pull request and the previous fix. 

Perhaps this collector should be removed?