### PR TITLE
Update github_pages.rb

### DIFF
--- a/lib/aquatone/detectors/github_pages.rb
+++ b/lib/aquatone/detectors/github_pages.rb
@@ -8,7 +8,7 @@ module Aquatone
         :description     => "GitHub static website hosting"
       }
 
-      APEX_VALUES          = %w(192.30.252.153 192.30.252.154).freeze
+      APEX_VALUES          = %w(192.30.252.153 192.30.252.154 185.199.108.153 185.199.109.153 185.199.110.153 185.199.111.153).freeze
       CNAME_VALUE          = ".github.io".freeze
       RESPONSE_FINGERPRINT = "There isn't a GitHub Pages site here.".freeze
 


### PR DESCRIPTION

Github has updated IP addresses for pointing a domain to github pages. While the old ones still work a warning message is displayed as shown:

<img src="https://user-images.githubusercontent.com/14029371/44616417-d64b6600-a86c-11e8-9a98-e75743ea4daa.png">

The new IP adresses are listed here:
https://help.github.com/articles/troubleshooting-custom-domains/