### PR TITLE
No longer die when a nameserver can't be resolved

### DIFF
--- a/lib/aquatone/domain.rb
+++ b/lib/aquatone/domain.rb
@@ -17,7 +17,13 @@ module Aquatone
         lookup      = parts[n..-1].join('.') + "."
         nameservers = nameserver.getresources(lookup, Resolv::DNS::Resource::IN::NS)
         if !nameservers.count.zero?
-          result = nameservers.map { |ns| nameserver.getaddress(ns.name.to_s).to_s }
+          result = nameservers.map do |ns|
+            begin
+              nameserver.getaddress(ns.name.to_s).to_s
+            rescue
+              nil
+            end
+          end.compact
           break
         end
       end


### PR DESCRIPTION
This kind of fixes #5 and #26. I am not sure if its the right fix, but it allowed me to get past the error.

This will make it so name servers that do not resolve will be ignored.