### PR TITLE
Use chromedp tabs instead of full instances (thanks to mzack9999)

### DIFF
--- a/agents/url_requester.go
+++ b/agents/url_requester.go
@@ -34,11 +34,20 @@ func (a *URLRequester) OnURL(url string) {
 	go func(url string) {
 		defer a.session.WaitGroup.Done()
 		http := Gorequest(a.session.Options)
+		ip := RandomIPv4Address()
+		if a.Session.Options.Waf {
+			ip = "127.0.0.1"
+		}
 		resp, _, errs := http.Get(url).
 			Set("User-Agent", RandomUserAgent()).
-			Set("X-Forwarded-For", RandomIPv4Address()).
-			Set("Via", fmt.Sprintf("1.1 %s", RandomIPv4Address())).
-			Set("Forwarded", fmt.Sprintf("for=%s;proto=http;by=%s", RandomIPv4Address(), RandomIPv4Address())).End()
+			Set("X-Client-IP", ip).
+			Set("X-Remote-IP", ip).
+			Set("X-Remote-Addr", ip).
+			Set("X-Forwarded-For", ip).
+			Set("X-OriginatingIP", ip).
+			Set("Via", "1.1 "+ip).
+			Set("Forwarded", "for="+ip+";proto=http;by="+ip).
+			End()
 		var status string
 		if errs != nil {
 			a.session.Stats.IncrementRequestFailed()

--- a/agents/url_requester.go
+++ b/agents/url_requester.go
@@ -35,7 +35,7 @@ func (a *URLRequester) OnURL(url string) {
 		defer a.session.WaitGroup.Done()
 		http := Gorequest(a.session.Options)
 		ip := RandomIPv4Address()
-		if a.Session.Options.Waf {
+		if *a.session.Options.Waf {
 			ip = "127.0.0.1"
 		}
 		resp, _, errs := http.Get(url).

--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -3,17 +3,25 @@ package agents
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/security"
+	"github.com/chromedp/chromedp"
+	"github.com/chromedp/chromedp/runner"
 	"github.com/michenriksen/aquatone/core"
 )
 
 type URLScreenshotter struct {
 	session    *core.Session
 	chromePath string
+	ctxt       context.Context
+	pool       *chromedp.Pool
 }
 
 func NewURLScreenshotter() *URLScreenshotter {
@@ -28,6 +36,8 @@ func (a *URLScreenshotter) Register(s *core.Session) error {
 	s.EventBus.SubscribeAsync(core.URLResponsive, a.OnURLResponsive, false)
 	a.session = s
 	a.locateChrome()
+	a.ctxt, _ = context.WithCancel(context.Background())
+	a.pool, _ = chromedp.NewPool()
 
 	return nil
 }
@@ -80,47 +90,89 @@ func (a *URLScreenshotter) locateChrome() {
 
 func (a *URLScreenshotter) screenshotURL(s string) {
 	filePath := a.session.GetFilePath(fmt.Sprintf("screenshots/%s.png", BaseFilenameFromURL(s)))
-	var chromeArguments = []string{
-		"--headless", "--disable-gpu", "--hide-scrollbars", "--mute-audio", "--disable-notifications",
-		"--disable-crash-reporter",
-		"--ignore-certificate-errors",
-		"--user-agent=" + RandomUserAgent(),
-		"--window-size=" + *a.session.Options.Resolution,
-		"--screenshot=" + filePath,
+
+	// allocate a chrome headless instance
+	c, err := a.pool.Allocate(a.ctxt,
+		runner.DisableGPU,
+		runner.Headless,
+		runner.ExecPath(a.chromePath),
+		runner.Flag("ignore-certificate-errors", true),
+		runner.Flag("disable-crash-reporter", true),
+		runner.Flag("disable-notifications", true),
+		runner.Flag("hide-scrollbars", true),
+		runner.Flag("window-size", *a.session.Options.Resolution),
+		runner.Flag("user-agent", RandomUserAgent()),
+		runner.Flag("mute-audio", true),
+		runner.Flag("incognito", true),
+	)
+	defer c.Release()
+
+	// screenshot buffer
+	var picbuf []byte
+
+	// set headers
+	ip := RandomIPv4Address()
+	if *a.session.Options.Waf {
+		ip = "127.0.0.1"
+	}
+	headers := map[string]interface{}{
+		"X-Client-IP":     ip,
+		"X-Remote-IP":     ip,
+		"X-Remote-Addr":   ip,
+		"X-Forwarded-For": ip,
+		"X-OriginatingIP": ip,
+		"Via":             "1.1 " + ip,
+		"Forwarded":       "for=" + ip + ";proto=http;by=" + ip,
 	}
 
-	if os.Geteuid() == 0 {
-		chromeArguments = append(chromeArguments, "--no-sandbox")
+	// create a new tab and snap it
+	t := chromedp.Tasks{
+		network.Enable(),
+		network.SetExtraHTTPHeaders(network.Headers(headers)),
+		security.SetIgnoreCertificateErrors(true),
+		chromedp.Navigate(s),
+		chromedp.Sleep(time.Second * 5),
+		chromedp.ActionFunc(func(ctxt context.Context, h cdp.Executor) error {
+			picbuf, err = page.CaptureScreenshot().Do(ctxt, h)
+			if err != nil {
+				a.session.Out.Debug("[%s] Error: %v\n", a.ID(), err)
+				a.session.Stats.IncrementScreenshotFailed()
+				a.session.Out.Error("%s: screenshot failed: %s\n", s, err)
+				return err
+			}
+			return nil
+		}),
 	}
 
-	if *a.session.Options.Proxy != "" {
-		chromeArguments = append(chromeArguments, "--proxy-server="+*a.session.Options.Proxy)
-	}
-
-	chromeArguments = append(chromeArguments, s)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.session.Options.ScreenshotTimeout)*time.Millisecond)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, a.chromePath, chromeArguments...)
-	if err := cmd.Start(); err != nil {
+	// run tasks
+	err = c.Run(a.ctxt, t)
+	if err != nil {
 		a.session.Out.Debug("[%s] Error: %v\n", a.ID(), err)
 		a.session.Stats.IncrementScreenshotFailed()
 		a.session.Out.Error("%s: screenshot failed: %s\n", s, err)
 		return
 	}
 
-	if err := cmd.Wait(); err != nil {
-		a.session.Stats.IncrementScreenshotFailed()
+	// write to disk
+	err = ioutil.WriteFile(filePath, picbuf, 0644)
+	if err != nil {
 		a.session.Out.Debug("[%s] Error: %v\n", a.ID(), err)
-		if ctx.Err() == context.DeadlineExceeded {
-			a.session.Out.Error("%s: screenshot timed out\n", s)
-			return
+		a.session.Stats.IncrementScreenshotFailed()
+		a.session.Out.Error("%s: screenshot failed: %s\n", s, err)
+		return
+	}
+
+	/*
+		if os.Geteuid() == 0 {
+			chromeArguments = append(chromeArguments, "--no-sandbox")
 		}
 
-		a.session.Out.Error("%s: screenshot failed: %s\n", s, err)
-		return
-	}
+		if *a.session.Options.Proxy != "" {
+			chromeArguments = append(chromeArguments, "--proxy-server="+*a.session.Options.Proxy)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*a.session.Options.ScreenshotTimeout)*time.Millisecond)
+	*/
 
 	a.session.Stats.IncrementScreenshotSuccessful()
 	a.session.Out.Info("%s: %s\n", s, Green("screenshot successful"))

--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -102,10 +102,15 @@ func (a *URLScreenshotter) screenshotURL(s string) {
 		runner.Flag("hide-scrollbars", true),
 		runner.Flag("window-size", *a.session.Options.Resolution),
 		runner.Flag("user-agent", RandomUserAgent()),
+		runner.Flag("no-sandbox", true),
 		runner.Flag("mute-audio", true),
 		runner.Flag("incognito", true),
 	)
 	defer c.Release()
+	if err != nil {
+		a.session.Out.Error("%s: screenshot failed: %s\n", s, err)
+		return
+	}
 
 	// screenshot buffer
 	var buf []byte

--- a/core/options.go
+++ b/core/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	ScreenshotTimeout *int
 	Nmap              *bool
 	SaveBody          *bool
+	Waf               *bool
 	Silent            *bool
 	Debug             *bool
 }
@@ -35,6 +36,7 @@ func ParseOptions() (Options, error) {
 		ScreenshotTimeout: flag.Int("screenshot-timeout", 30*1000, "Timeout in miliseconds for screenshots"),
 		Nmap:              flag.Bool("nmap", false, "Parse input as Nmap/Masscan XML"),
 		SaveBody:          flag.Bool("save-body", true, "Save response bodies to files"),
+		Waf:               flag.Bool("waf", false, "Attempt to bypass weak ACLs"),
 		Silent:            flag.Bool("silent", false, "Suppress all output except for errors"),
 		Debug:             flag.Bool("debug", false, "Print debugging information"),
 	}


### PR DESCRIPTION
this spawns tabs instead of full chrome instances; it also allows for custom headers to be set. the `security` context should be able to ignore and skip ssl cert verification in any case. this still needs some tweaking (disabling the sandbox, and setting the proxy flag) but it's a good start. the chromedp approach is mzack9999's idea, not mine