### PR TITLE
fix different urls getting the same filename

### DIFF
--- a/agents/util.go
+++ b/agents/util.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"crypto/md5"
 	"crypto/tls"
 	"fmt"
 	"math/rand"
@@ -107,6 +108,10 @@ func BaseFilenameFromURL(s string) string {
 	}
 	host := strings.Replace(u.Host, ":", "__", 1)
 	filename := fmt.Sprintf("%s__%s", u.Scheme, strings.Replace(host, ".", "_", -1))
+	pathAndQuery := u.Path + u.RawQuery
+	if len(pathAndQuery) > 0 {
+		filename = fmt.Sprintf("%s__%x", filename, md5.Sum([]byte(pathAndQuery)))
+	}
 	return strings.ToLower(filename)
 }
 

--- a/core/session.go
+++ b/core/session.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -246,6 +247,10 @@ func (s *Session) BaseFilenameFromURL(stru string) string {
 	}
 	host := strings.Replace(u.Host, ":", "__", 1)
 	filename := fmt.Sprintf("%s__%s", u.Scheme, strings.Replace(host, ".", "_", -1))
+	pathAndQuery := u.Path + u.RawQuery
+	if len(pathAndQuery) > 0 {
+		filename = fmt.Sprintf("%s__%x", filename, md5.Sum([]byte(pathAndQuery)))
+	}
 	return strings.ToLower(filename)
 }
 


### PR DESCRIPTION
Fixes https://github.com/michenriksen/aquatone/issues/147
Added path and query of url in filename to differentiate it from another url sharing the scheme and host.
To maintain a readable and relatively short filename, I used md5 to hash path and query.

First time I dev in golang so there may be a better way to do.