### PR TITLE
Add generic timeout flag. only use nmap open ports. 

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -8,6 +8,7 @@ import (
 
 type Options struct {
 	Threads           *int
+	Timeout           *int
 	OutDir            *string
 	Proxy             *string
 	ChromePath        *string
@@ -25,6 +26,7 @@ type Options struct {
 func ParseOptions() (Options, error) {
 	options := Options{
 		Threads:           flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),
+		Timeout:	       flag.Int("timeout", 0, "Generic timeout for everithing. (specific timeouts will be ignored if set)"),
 		OutDir:            flag.String("out", ".", "Directory to write files to"),
 		Proxy:             flag.String("proxy", "", "Proxy to use for HTTP requests"),
 		ChromePath:        flag.String("chrome-path", "", "Full path to the Chrome/Chromium executable to use. By default, aquatone will search for Chrome or Chromium"),
@@ -40,6 +42,12 @@ func ParseOptions() (Options, error) {
 	}
 
 	flag.Parse()
+
+	if *options.Timeout != 0{
+		*options.ScanTimeout = *options.Timeout
+		*options.HTTPTimeout = *options.Timeout
+		*options.ScanTimeout = *options.Timeout
+	}
 
 	return options, nil
 }

--- a/main.go
+++ b/main.go
@@ -94,7 +94,11 @@ func main() {
 
 	sess.Out.Important("Targets    : %d\n", len(targets))
 	sess.Out.Important("Threads    : %d\n", *sess.Options.Threads)
-	sess.Out.Important("Ports      : %s\n", strings.Trim(strings.Replace(fmt.Sprint(sess.Ports), " ", ", ", -1), "[]"))
+	if *sess.Options.Nmap {
+		sess.Out.Important("Ports      : nmap open ports\n")
+	}else{
+		sess.Out.Important("Ports      : %s\n", strings.Trim(strings.Replace(fmt.Sprint(sess.Ports), " ", ", ", -1), "[]"))
+	}
 	sess.Out.Important("Output dir : %s\n\n", *sess.Options.OutDir)
 
 	for _, target := range targets {

--- a/parsers/nmap.go
+++ b/parsers/nmap.go
@@ -48,6 +48,11 @@ func (p *NmapParser) isHTTPPort(port int) bool {
 func (p *NmapParser) hostToURLs(host nmap.Host) []string {
 	var urls []string
 	for _, port := range host.Ports {
+
+		if port.State.State != "open"{
+			continue
+		}
+
 		var protocol string
 		if port.Service.Name == "ssl" {
 			protocol = "https"


### PR DESCRIPTION
Only take into account open ports from scan result.
Change the message of used ports to avoid confusion.
fix #168 

Add a generic timeout flag to be used to overwrite all timeouts at the same time.
fix #169