### PR TITLE
added technology to file logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 aquatone
 vendor/
 build/
+info/
 screenshots/
 headers/
 html/

--- a/core/session.go
+++ b/core/session.go
@@ -229,7 +229,7 @@ func (s *Session) initWaitGroup() {
 }
 
 func (s *Session) initDirectories() {
-	for _, d := range []string{"headers", "html", "screenshots"} {
+	for _, d := range []string{"info", "headers", "html", "screenshots"} {
 		d = s.GetFilePath(d)
 		if _, err := os.Stat(d); os.IsNotExist(err) {
 			err = os.MkdirAll(d, 0755)


### PR DESCRIPTION
For those using aquatone with scripting and automation, the `aquatone_report.html` is not very helpful. The only information there which is nowhere else is the full URL (matched against the hashed filename) and technology fingerprinting.

This small PR adds this to an `OUTPUT_DIR/info/SITE_HASH.txt` file. Full URL is useful to avoid having to keep track of the original input file, as it doesn't take that much space in the file and then the fingerprints found.