### PR TITLE
Add Chromium virtual-time-budget flag

### DIFF
--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -133,6 +133,7 @@ func (a *URLScreenshotter) screenshotPage(page *core.Page) {
 		"--user-agent=" + RandomUserAgent(),
 		"--window-size=" + *a.session.Options.Resolution,
 		"--screenshot=" + a.session.GetFilePath(filePath),
+		"--virtual-time-budget=" + strconv.Itoa(*a.session.Options.ScreenshotTimeout),
 	}
 
 	if os.Geteuid() == 0 {


### PR DESCRIPTION
Fixes an issue with screenshots capturing before the entire page can load. Setting flag to argument ScreenshotTimeout for ease of use.

Argument description here: https://peter.sh/experiments/chromium-command-line-switches/

I've had success where after scanning lots of assets, many of the pages would contain white/blank screenshots. Adding in the virtual-time-budget argument resolved this issue for me.