### PR TITLE
Added Similarity and InputFile Options

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -23,6 +23,8 @@ type Options struct {
 	Silent            *bool
 	Debug             *bool
 	Version           *bool
+	Similarity	  *float64
+	InputFile	  *string
 }
 
 func ParseOptions() (Options, error) {
@@ -43,6 +45,8 @@ func ParseOptions() (Options, error) {
 		Silent:            flag.Bool("silent", false, "Suppress all output except for errors"),
 		Debug:             flag.Bool("debug", false, "Print debugging information"),
 		Version:           flag.Bool("version", false, "Print current Aquatone version"),
+		Similarity:	   flag.Float64("similarity",0.80,"Cluster Similarity Float for Screenshots. Default 0.80"),
+		InputFile:	   flag.String("inputfile","","Input file to parse hosts (Nmap or Raw) rather than STDIN"),
 	}
 
 	flag.Parse()


### PR DESCRIPTION
Added -similarity Option which takes a custom floating point to change the clustering percentage. I've had success with more strict, and less strict values (~78%), makes it easier to just make an option rather than rebuild from source each time

Added -inputfile Option which allows aquatone to read the hosts (nmap or raw) from a direct file rather than using STDIN. I have some other tools that are dependent on input from a file, makes my life easier than modifying those tools too.

Thanks for the awesome tool!