### PR TITLE
[feature] dump session json on signal

### DIFF
--- a/core/dump_nix.go
+++ b/core/dump_nix.go
@@ -1,0 +1,23 @@
+// +build linux darwin
+
+package core
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func DumpSessionOnSig(sess *Session) {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGUSR1)
+	for range sigChan {
+		sess.Lock()
+		err := sess.SaveToFile("aquatone_session.json")
+		if err != nil {
+			sess.Out.Error("Failed to write session file")
+			sess.Out.Debug("Err: %s", err.Error())
+		}
+		sess.Unlock()
+	}
+}

--- a/core/dump_windows.go
+++ b/core/dump_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package core
+
+func DumpSessionOnSig(sess *Session) {
+	// not supported
+}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	go core.DumpSessionOnSig(sess)
+
 	agents.NewTCPPortScanner().Register(sess)
 	agents.NewURLPublisher().Register(sess)
 	agents.NewURLRequester().Register(sess)


### PR DESCRIPTION
Many of my scans take a while or are only waiting on some conns to timeout, so I'd like to be able to review a partial report before the scan finishes. This change dumps the json session file on SIGUSR1, so I can generate the report.