### PR TITLE
Always screenshot IP when parsing xml.

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FrankSpierings/aquatone/parsers"
 	"github.com/google/uuid"
 	"github.com/michenriksen/aquatone/agents"
 	"github.com/michenriksen/aquatone/core"
-	"github.com/michenriksen/aquatone/parsers"
 )
 
 var (

--- a/parsers/nmap.go
+++ b/parsers/nmap.go
@@ -69,13 +69,12 @@ func (p *NmapParser) hostToURLs(host nmap.Host) []string {
 			for _, hostname := range host.Hostnames {
 				urls = append(urls, core.HostAndPortToURL(hostname.Name, port.PortId, protocol))
 			}
-		} else {
-			for _, address := range host.Addresses {
-				if address.AddrType == "mac" {
-					continue
-				}
-				urls = append(urls, core.HostAndPortToURL(address.Addr, port.PortId, protocol))
+		}
+		for _, address := range host.Addresses {
+			if address.AddrType == "mac" {
+				continue
 			}
+			urls = append(urls, core.HostAndPortToURL(address.Addr, port.PortId, protocol))
 		}
 	}
 


### PR DESCRIPTION
The application will now always screenshot the IP-adres from a Nmap XML scan, since the reverse DNS (PTR) name as retrieved from hostname might not be resolvable.