### PR TITLE
Fix Error: signal: trace/breakpoint trap #196 with adding extra Chrom…

### DIFF
--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -129,6 +129,7 @@ func (a *URLScreenshotter) screenshotPage(page *core.Page) {
 		"--headless", "--disable-gpu", "--hide-scrollbars", "--mute-audio", "--disable-notifications",
 		"--no-first-run", "--disable-crash-reporter", "--ignore-certificate-errors", "--incognito",
 		"--disable-infobars", "--disable-sync", "--no-default-browser-check",
+                "--disable-features=VizDisplayCompositor",
 		"--user-data-dir=" + a.tempUserDirPath,
 		"--user-agent=" + RandomUserAgent(),
 		"--window-size=" + *a.session.Options.Resolution,


### PR DESCRIPTION
Fix Error: signal: trace/breakpoint trap #196 with adding extra Chrome parameter.

It is only tested on a RPI3 where it works nicely.