### PR TITLE
New feature : Screenshot delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ If you for some reason don't trust the pre-compiled binaries, you can also compi
     	Timeout in miliseconds for port scans (default 100)
   -screenshot-timeout int
     	Timeout in miliseconds for screenshots (default 30000)
+  -screenshot-delay int
+    	Delay before taking screenshot (default 0 => deactivated)
   -session string
     	Load Aquatone session file and generate HTML report
   -silent
@@ -101,6 +103,16 @@ Aquatone also supports aliases of built-in port lists to make it easier for you:
 **Example:**
 
     $ cat hosts.txt | aquatone -ports large
+
+
+### Screenshot delay
+
+For example delaying capture, could be useful for javascript rendered pages (sleeping a couple of ms).
+The system waits the specified number of virtual milliseconds before deeming the page to be ready.
+
+**Example:**
+
+    $ cat hosts.txt | aquatone -screenshot-delay 10000
 
 
 ### Usage examples

--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -142,6 +142,10 @@ func (a *URLScreenshotter) screenshotPage(page *core.Page) {
 	if *a.session.Options.Proxy != "" {
 		chromeArguments = append(chromeArguments, "--proxy-server="+*a.session.Options.Proxy)
 	}
+	
+	if *a.session.Options.ScreenshotDelay > 0 {
+		chromeArguments = append(chromeArguments, "--virtual-time-budget="+*a.session.Options.ScreenshotDelay)
+	}
 
 	chromeArguments = append(chromeArguments, page.URL)
 

--- a/agents/url_screenshotter.go
+++ b/agents/url_screenshotter.go
@@ -144,7 +144,7 @@ func (a *URLScreenshotter) screenshotPage(page *core.Page) {
 	}
 	
 	if *a.session.Options.ScreenshotDelay > 0 {
-		chromeArguments = append(chromeArguments, "--virtual-time-budget="+*a.session.Options.ScreenshotDelay)
+		chromeArguments = append(chromeArguments, fmt.Sprint("--virtual-time-budget=", *a.session.Options.ScreenshotDelay))
 	}
 
 	chromeArguments = append(chromeArguments, page.URL)

--- a/core/options.go
+++ b/core/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	ScanTimeout       *int
 	HTTPTimeout       *int
 	ScreenshotTimeout *int
+	ScreenshotDelay *int
 	Nmap              *bool
 	SaveBody          *bool
 	Silent            *bool
@@ -38,6 +39,7 @@ func ParseOptions() (Options, error) {
 		ScanTimeout:       flag.Int("scan-timeout", 100, "Timeout in miliseconds for port scans"),
 		HTTPTimeout:       flag.Int("http-timeout", 3*1000, "Timeout in miliseconds for HTTP requests"),
 		ScreenshotTimeout: flag.Int("screenshot-timeout", 30*1000, "Timeout in miliseconds for screenshots"),
+		ScreenshotDelay:   flag.Int("screenshot-delay", 0, "The delay before taking screenshots"),
 		Nmap:              flag.Bool("nmap", false, "Parse input as Nmap/Masscan XML"),
 		SaveBody:          flag.Bool("save-body", true, "Save response bodies to files"),
 		Silent:            flag.Bool("silent", false, "Suppress all output except for errors"),

--- a/core/options.go
+++ b/core/options.go
@@ -18,7 +18,7 @@ type Options struct {
 	ScanTimeout       *int
 	HTTPTimeout       *int
 	ScreenshotTimeout *int
-	ScreenshotDelay *int
+	ScreenshotDelay   *int
 	Nmap              *bool
 	SaveBody          *bool
 	Silent            *bool


### PR DESCRIPTION
Add the possibility to delay the screenshot with the help of  chrome `--virtual-time-budget` argument.
Gives javascript websites the necessary time to render.

**For example (same url, different results) :**

Without delay :

    $ cat targets.txt | aquatone

![without](https://user-images.githubusercontent.com/670645/80742805-46b78980-8b1c-11ea-8001-d1d7e578d3f5.png)

With delay : 

    $ cat targets.txt | aquatone -screenshot-delay 10000

![with](https://user-images.githubusercontent.com/670645/80742809-47502000-8b1c-11ea-8a89-a4452e30d81a.png)
