### PR TITLE
Add noreferrer to "Visit Page" button

### DIFF
--- a/static/report_template.html
+++ b/static/report_template.html
@@ -257,7 +257,7 @@
         </p>
       </div>
       <div class="card-footer">
-        <a href="#" class="btn btn-outline-primary btn-sm card-link" v-on:click="openDetailsModal">View Details</a> <a class="btn btn-outline-secondary btn-sm card-link float-right" :href="page.url" target="_blank">Visit Page</a>
+        <a href="#" class="btn btn-outline-primary btn-sm card-link" v-on:click="openDetailsModal">View Details</a> <a class="btn btn-outline-secondary btn-sm card-link float-right" :href="page.url" target="_blank" rel="noreferrer" >Visit Page</a>
       </div>
     </div>
   </script>


### PR DESCRIPTION
Hi!

Thanks for the super useful tool!

I noticed that my VPS IP was transmitted to my bug bounty targets when I click on "Visit Page" via the referrer header which I'd very much like to avoid. I'm sure most bug hunters are the same which is why I propose this quick change to solve this privacy issue.